### PR TITLE
Current version of Tensorflow depends on cudnn6

### DIFF
--- a/anpr_ocr/docker/Dockerfile
+++ b/anpr_ocr/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn6-devel
 
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH

--- a/anpr_ocr/docker/run.sh
+++ b/anpr_ocr/docker/run.sh
@@ -4,4 +4,6 @@ nvidia-docker run --rm -it \
 			--net=host \
 			-v `pwd`/../src:/workdir/src \
 			-v `pwd`/../data:/data \
+			-p 8888:8888 \
 			plate-number-recognition bash
+# jupyter notebook --port=8888 --no-browser --ip=0.0.0.0


### PR DESCRIPTION
Current container don't work from scratch.  Tensorflow want libcodnn.6.so
