### PR TITLE
fix LoadAnnotation assign bottom value

### DIFF
--- a/anpr/src/experiment1.ipynb
+++ b/anpr/src/experiment1.ipynb
@@ -91,7 +91,7 @@
     "    left = data[\"objects\"][0][\"points\"][\"exterior\"][0][0]\n",
     "    top = data[\"objects\"][0][\"points\"][\"exterior\"][0][1]\n",
     "    right = data[\"objects\"][0][\"points\"][\"exterior\"][1][0]\n",
-    "    bottom = data[\"objects\"][0][\"points\"][\"exterior\"][1][1]\n",
+    "    bottom = data[\"objects\"][0][\"points\"][\"exterior\"][2][1]\n",
     "    \n",
     "    return [left, top, right, bottom]"
    ]


### PR DESCRIPTION
Bottom value was assigned wrong, leading to wrong prediction of lower bounds. 